### PR TITLE
install libarchive-tools

### DIFF
--- a/2-archetect/Dockerfile
+++ b/2-archetect/Dockerfile
@@ -5,7 +5,7 @@ FROM ${REGISTRY_PREFIX}/debian:trixie-slim
 ENV TZ=UTC
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
-  git curl wget ca-certificates yq jq zip unzip gpg libssl-dev tzdata && \
+  git curl wget ca-certificates yq jq zip unzip libarchive-tools gpg libssl-dev tzdata && \
   rm -rf /var/lib/apt/lists/*
 
 # ARM64: https://github.com/archetect/archetect/releases/download/v2.0.7/archetect-v2.0.7-linux-arm64.tar.gz


### PR DESCRIPTION
Installing `bsdtar` via `libarchive-tools` so we can get access to things like

```
bsdtar -xf archive.zip --strip-components=1
```

to sanitize the directory names created by archetect