### PR TITLE
YP6M-2898 Add Bitnami-free Keycloak 26.6.4 image from the official distribution

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -434,6 +434,17 @@ jobs:
             builder_image_tag_arg: "" # unused
             image_tag_arg: "" # Alpine base image
             variants: "linux/amd64,linux/arm64"
+          # Official Keycloak distribution on the ybor debian trixie-slim base (YP6M-2898).
+          # NOTE: the floating "26" tag intentionally stays on the legacy bitnami-derived
+          # image above until production migrates (filesystem layout differs).
+          - name: keycloak
+            version_tag: "26.6.4"
+            dockerfile: 2-keycloak/26.6.4/Dockerfile
+            context: 2-keycloak/26.6.4
+            version_arg: "26.6.4" # keycloak dist version; DIST_SHA256 in the Dockerfile must match
+            builder_image_tag_arg: "" # unused
+            image_tag_arg: "" # unused
+            variants: "linux/amd64,linux/arm64"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/2-keycloak/26.6.4/Dockerfile
+++ b/2-keycloak/26.6.4/Dockerfile
@@ -1,0 +1,73 @@
+ARG REGISTRY_PREFIX=ybor
+
+# ---------------------------------------------------------------------------
+# Build stage: fetch the official Keycloak distribution, verify its checksum,
+# and produce an optimized (pre-augmented) server.
+#
+# Build options are BAKED into the image here. Consumers must run
+# `start --optimized`, and runtime env vars for build options (KC_DB,
+# KC_HEALTH_ENABLED, KC_METRICS_ENABLED, KC_FEATURES_DISABLED) are ignored.
+# Downstream images that add provider JARs MUST re-run `kc.sh build` with
+# these exact same flags (see 2-keycloak/README.md).
+# ---------------------------------------------------------------------------
+FROM ${REGISTRY_PREFIX}/debian:trixie-slim AS build
+
+ARG VERSION=26.6.4
+# sha256 of keycloak-${VERSION}.tar.gz from the GitHub release asset digest.
+# Must be updated in lockstep with VERSION.
+ARG DIST_SHA256=386b566bbea05527226e275c43e5cf6f218896ad2441ac4be5c39f1226772e8f
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    openjdk-21-jre-headless \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -q -O /tmp/keycloak.tar.gz \
+      "https://github.com/keycloak/keycloak/releases/download/${VERSION}/keycloak-${VERSION}.tar.gz" && \
+    echo "${DIST_SHA256}  /tmp/keycloak.tar.gz" | sha256sum -c - && \
+    tar -xzf /tmp/keycloak.tar.gz -C /opt && \
+    mv /opt/keycloak-${VERSION} /opt/keycloak && \
+    rm /tmp/keycloak.tar.gz
+
+RUN /opt/keycloak/bin/kc.sh build \
+      --db=postgres \
+      --health-enabled=true \
+      --metrics-enabled=true \
+      --features-disabled=impersonation
+
+# ---------------------------------------------------------------------------
+# Runtime stage
+# ---------------------------------------------------------------------------
+FROM ${REGISTRY_PREFIX}/debian:trixie-slim
+
+LABEL MAINTAINER="ybor"
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    openjdk-21-jre-headless \
+    && rm -rf /var/lib/apt/lists/* && \
+    useradd --system --uid 1001 --gid 0 --home-dir /opt/keycloak --shell /usr/sbin/nologin keycloak
+
+COPY --from=build --chown=1001:0 /opt/keycloak /opt/keycloak
+
+# Group-writable so downstream provider images can re-augment as USER 1001
+RUN chmod -R g+rwX /opt/keycloak
+
+ENV LANG=C.UTF-8 \
+    KC_RUN_IN_CONTAINER=true \
+    PATH="/opt/keycloak/bin:${PATH}"
+
+USER 1001
+
+# smoke test
+RUN kc.sh --version
+
+EXPOSE 8080 8443 9000
+
+ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]
+CMD ["start", "--optimized"]

--- a/2-keycloak/README.md
+++ b/2-keycloak/README.md
@@ -1,0 +1,47 @@
+# keycloak
+
+Two image lineages live here during the Bitnami migration (YP6M-2897):
+
+| Directory | Lineage | Layout | Consumers |
+|---|---|---|---|
+| `26.6.4/` | **Official Keycloak distribution** on the ybor hardened `debian:trixie-slim` base | `/opt/keycloak` | New deployments (p6m-keycloak chart >= 0.2.0) |
+| `26.3.1-debian-12-r2/` | Legacy Bitnami-derived (patch layer over our last mirrored Bitnami image) | `/opt/bitnami/keycloak` | Production until migrated — do not remove; the floating `26` tag stays pointed here |
+
+## Official-distribution image (`26.6.4/`)
+
+- Distribution tarball is downloaded from the GitHub release and **sha256-verified**
+  (`DIST_SHA256` build arg must be updated in lockstep with `VERSION`).
+- Runs an **optimized build** (`kc.sh build`) at image-build time with:
+  `--db=postgres --health-enabled=true --metrics-enabled=true --features-disabled=impersonation`
+- Runs as non-root UID `1001` (group `0`), `ENTRYPOINT kc.sh`, `CMD start --optimized`.
+- Ports: `8080` (http), `8443` (https), `9000` (management — health/metrics).
+
+Because the server is pre-augmented, **runtime env vars for build options are
+ignored** (`KC_DB`, `KC_HEALTH_ENABLED`, `KC_METRICS_ENABLED`, `KC_FEATURES_*`).
+Runtime options (`KC_DB_URL`, `KC_DB_USERNAME`, `KC_DB_PASSWORD`, `KC_HOSTNAME`,
+`KC_HTTP_ENABLED`, `KC_PROXY_HEADERS`, `KC_CACHE_STACK`, `KC_LOG*`, ...) work as usual.
+
+## Baking in provider JARs (downstream images)
+
+Custom SPI providers must be added in a downstream image and the server
+**re-augmented with the exact same build flags**, or they will not load under
+`start --optimized`:
+
+```dockerfile
+FROM ghcr.io/p6m-dev/keycloak:26.6.4
+COPY --chown=1001:0 providers/*.jar /opt/keycloak/providers/
+RUN /opt/keycloak/bin/kc.sh build \
+      --db=postgres \
+      --health-enabled=true \
+      --metrics-enabled=true \
+      --features-disabled=impersonation
+```
+
+Tag convention: `<keycloak-version>-provider-<provider-version>` (e.g. `26.6.4-provider-1.0.5`).
+
+## Upgrading Keycloak
+
+1. Create `2-keycloak/<new-version>/` from the current official-dist Dockerfile.
+2. Update `VERSION` and `DIST_SHA256` (asset digest on the GitHub release page).
+3. Add matrix entries in `.github/workflows/build-push.yaml` for the new version tag.
+4. Keep the previous version directory until all consumers have moved.


### PR DESCRIPTION
## Summary

[YP6M-2898](https://ybor.atlassian.net/browse/YP6M-2898) (epic [YP6M-2897](https://ybor.atlassian.net/browse/YP6M-2897)): first step of migrating Keycloak off Bitnami images, which now require payment.

Adds `2-keycloak/26.6.4/` — a Keycloak image built **from the official distribution tarball** on the ybor hardened `debian:trixie-slim` base, with no Bitnami lineage:

- Distribution tarball sha256-verified (`DIST_SHA256` build arg, pinned to the GitHub release asset digest)
- OpenJDK 21 from the Debian 13 archive, so security patches flow through the existing weekly pkgsum rebuild
- Pre-augmented optimized build: `kc.sh build --db=postgres --health-enabled=true --metrics-enabled=true --features-disabled=impersonation`
- Non-root UID 1001 (group 0), `ENTRYPOINT kc.sh`, `CMD start --optimized`, smoke test `kc.sh --version`
- Multi-arch `linux/amd64,linux/arm64` matrix entry

**Left untouched on purpose:** `2-keycloak/26.3.1-debian-12-r2/` and the floating `26` tag — production still consumes them, and the filesystem layout moved (`/opt/bitnami/keycloak` → `/opt/keycloak`), so repointing `26` would silently break consumers. They retire in a follow-up after prod migrates.

`2-keycloak/README.md` documents both lineages and the mandatory downstream provider-JAR pattern (`COPY` + re-run `kc.sh build` with identical flags).

## Verification

Local (arm64):
- `docker build` of the trixie-slim base then this image succeeds; checksum verification passes
- `id` → `uid=1001(keycloak) gid=0(root)`; `kc.sh show-config` shows `kc.db = postgres (Persisted)`, health/metrics/features-disabled persisted
- Full boot against PostgreSQL 16: `GET :9000/health/ready` → `UP` (cluster, database, initialized checks all UP), master realm + bootstrap admin created

Downstream consumers: `p6m-keycloak` chart 0.2.0 (YP6M-2900) and the a1p provider image rebuild (YP6M-2899) follow in separate PRs.

**Tooling**

| Skills Used | Agents Used |
|-------------|-------------|
| `ybor-standards:git` | `Claude Fable 5` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwki7SxMCs5TQyugtj5NPG


[YP6M-2898]: https://ybor.atlassian.net/browse/YP6M-2898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[YP6M-2897]: https://ybor.atlassian.net/browse/YP6M-2897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ