### PR TITLE
YP6M-3288 Add archetect v3 server image; fix P6M_-prefixed Artifactory secret names

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -118,8 +118,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: p6m.jfrog.io
-          username: ${{ secrets.ARTIFACTORY_USERNAME }}
-          password: ${{ secrets.ARTIFACTORY_IDENTITY_TOKEN }}
+          username: ${{ secrets.P6M_ARTIFACTORY_USERNAME }}
+          password: ${{ secrets.P6M_ARTIFACTORY_IDENTITY_TOKEN }}
       - name: Build and push
         id: build-push
         uses: docker/build-push-action@v6
@@ -301,8 +301,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: p6m.jfrog.io
-          username: ${{ secrets.ARTIFACTORY_USERNAME }}
-          password: ${{ secrets.ARTIFACTORY_IDENTITY_TOKEN }}
+          username: ${{ secrets.P6M_ARTIFACTORY_USERNAME }}
+          password: ${{ secrets.P6M_ARTIFACTORY_IDENTITY_TOKEN }}
       - name: Build and push
         id: build-push
         uses: docker/build-push-action@v6
@@ -344,6 +344,26 @@ jobs:
             context: 2-archetect
             version_tag: "2"
             builder_image_tag_arg: "v2.1.0" # TODO UNPIN THIS
+            image_tag_arg: "" # unused
+            variants: "linux/amd64,linux/arm64"
+          # Archetect v3, server-shaped (YP6M-3288): `archetect server` (gRPC :8080) by
+          # default; override the command for job-style renders (same CLI + tool set as
+          # v2). Floating "3" and pinned entries, keycloak-style; keep both version_arg
+          # values in sync when bumping.
+          - name: archetect
+            version_tag: "3"
+            dockerfile: 2-archetect/v3/Dockerfile
+            context: 2-archetect/v3
+            version_arg: "v3.4.3" # archetect release tag
+            builder_image_tag_arg: "" # unused
+            image_tag_arg: "" # unused
+            variants: "linux/amd64,linux/arm64"
+          - name: archetect
+            version_tag: "3.4.3"
+            dockerfile: 2-archetect/v3/Dockerfile
+            context: 2-archetect/v3
+            version_arg: "v3.4.3" # archetect release tag
+            builder_image_tag_arg: "" # unused
             image_tag_arg: "" # unused
             variants: "linux/amd64,linux/arm64"
           - name: cloudflared
@@ -482,8 +502,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: p6m.jfrog.io
-          username: ${{ secrets.ARTIFACTORY_USERNAME }}
-          password: ${{ secrets.ARTIFACTORY_IDENTITY_TOKEN }}
+          username: ${{ secrets.P6M_ARTIFACTORY_USERNAME }}
+          password: ${{ secrets.P6M_ARTIFACTORY_IDENTITY_TOKEN }}
       - name: Build and push
         id: build-push
         uses: docker/build-push-action@v6

--- a/2-archetect/v3/Dockerfile
+++ b/2-archetect/v3/Dockerfile
@@ -1,0 +1,45 @@
+ARG REGISTRY_PREFIX=ybor
+FROM ${REGISTRY_PREFIX}/debian:trixie-slim
+
+# Archetect v3, server-shaped (YP6M-3288): runs `archetect server` (gRPC :8080) by
+# default for long-lived deployments; job-style consumers (Argo render workflows, EDE
+# init containers) override the command and get the same CLI the v2 image provided.
+# The v2 tool set is intentionally retained for those workflows (bsdtar, jq, zip, ...).
+ENV TZ=UTC
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  git curl wget ca-certificates yq jq zip unzip libarchive-tools gpg libssl-dev tzdata && \
+  rm -rf /var/lib/apt/lists/*
+
+# VERSION is the workflow's general-purpose version build-arg (matrix.version_arg).
+ARG VERSION=v3.4.3
+ENV ARCHETECT_VERSION=${VERSION}
+RUN set -eux; \
+  dpkgArch="$(dpkg --print-architecture)"; \
+  case "${dpkgArch##*-}" in \
+  amd64) arch='x86_64' ;; \
+  armhf | arm64) arch='arm64' ;; \
+  *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+  esac; \
+  url="https://github.com/archetect/archetect/releases/download/${ARCHETECT_VERSION}/archetect-${ARCHETECT_VERSION}-linux-${arch}.tar.gz"; \
+  wget -q "$url"; \
+  tar -xzf "archetect-${ARCHETECT_VERSION}-linux-${arch}.tar.gz" --strip-components=1 -C /usr/local/bin; \
+  rm "archetect-${ARCHETECT_VERSION}-linux-${arch}.tar.gz"; \
+  chmod +x /usr/local/bin/archetect; \
+  archetect --version
+
+# Non-root. All three XDG trees (config, cache, data) live under HOME and must be
+# writable: the git cache materializes archetype trees at render time. Catalog
+# configuration is file-only — mount it at /home/archetect/.config/archetect/archetect.yaml.
+RUN useradd --create-home --uid 10001 archetect && \
+  mkdir -p /home/archetect/workspace && \
+  chown -R archetect:archetect /home/archetect
+USER archetect
+ENV HOME=/home/archetect
+# The server absorbs an archetect.yaml from its CWD, silently replacing the configured
+# catalog — pin the working directory to one deployments keep empty.
+WORKDIR /home/archetect/workspace
+
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/archetect"]
+CMD ["server"]


### PR DESCRIPTION
## What

Two changes — the first unblocks **every** build in this repo:

1. **Fix stale Artifactory secret names.** All three tiers' "Login to Artifactory Container Registry" steps still referenced `secrets.ARTIFACTORY_USERNAME` / `secrets.ARTIFACTORY_IDENTITY_TOKEN`. The org's rename effort prefixed these with `P6M_`, so logins fail with `Username and password required` (this PR's first CI run demonstrated it; the weekly scheduled build will fail identically). All references now use `secrets.P6M_ARTIFACTORY_*`.

2. **Archetect v3 server image** (`2-archetect/v3/Dockerfile` + two `app`-matrix entries, floating `3` and pinned `3.4.3`, keycloak-style) — published to the standard three registries like every other image here. Archetect v3.4.3 release binary on the org `debian:trixie-slim` base; **non-root** (uid 10001); `CMD ["server"]` (gRPC :8080). Job-style consumers (Argo render workflows, EDE init containers) override the command and get the same CLI + tool set (`bsdtar`, `jq`, `zip`, …) as the v2 image. Catalog configuration is file-only: mount at `/home/archetect/.config/archetect/archetect.yaml`; the working directory is pinned to an empty dir so a stray `archetect.yaml` in cwd can't silently replace the mounted catalog.

## Why

Ybor Studio is moving generation from the fire-and-forget headless job (`p6m-run/p6m-archetect` pulling `ybor/archetect:2` = archetect v2.1.0) to Archetect 3's gRPC server: interface inference (`DescribeArchetype`), interactive prompting (`StreamingApi`), client-owned materialization. Proven end-to-end in `ybor-studio/prova-ybor-studio` (acceptance suite green, incl. rendering `p6m/rust/services/grpc` through the containerized server).

**Requires archetect ≥ 3.4.3**: earlier servers ignored their action argument and silently rendered the first catalog entry on pathless renders (fixed upstream in [archetect/archetect](https://github.com/archetect/archetect) v3.4.3, `proofs/server/action_resolution_test.lua`).

## Verification

- Workflow YAML parses (yq): jobs `base`/`lang`/`app`; archetect matrix entries `2`, `3`, `3.4.3`; 6 `P6M_ARTIFACTORY` references.
- New secret names confirmed against `p6m-actions/docker-repository-login` docs (`P6M_ARTIFACTORY_USERNAME` / `P6M_ARTIFACTORY_IDENTITY_TOKEN`).
- The same Dockerfile content (plus a baked test catalog) is exercised by `prova-ybor-studio`'s acceptance suite against v3.4.3: server healthy, DescribeArchetype over the wire, client-side materialization, real p6m archetype render — all green.
- PR CI should now get past the Artifactory login and build/push `*-pr-27` tags as pre-merge verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)